### PR TITLE
Add MANIFEST.in

### DIFF
--- a/minimal-webapp/MANIFEST.in
+++ b/minimal-webapp/MANIFEST.in
@@ -1,0 +1,2 @@
+
+recursive-include minimal_webapp *


### PR DESCRIPTION
Add missing MANIFEST.in, similar to other webapps, required to include templates etc in the python build.
See https://forum.image.sc/t/omero-web-app-development/67512

To test:

```
$ pip install git+https://github.com/will-moore/omero-web-apps-examples.git@manifest#subdirectory=minimal-webapp
$ pip show minimal-webapp
```
Then check that 
``` path/to/site-packages/minimal_webapp``` should contain ```minimal_webapp/templates/minimal_webapp/index.html```