### PR TITLE
Update import to support Django 4

### DIFF
--- a/minimal-webapp/minimal_webapp/urls.py
+++ b/minimal-webapp/minimal_webapp/urls.py
@@ -15,12 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
 
     # index 'home page' of the app
-    url(r'^$', views.index, name='minimal_webapp_index'),
+    re_path(r'^$', views.index, name='minimal_webapp_index'),
 ]

--- a/react-webapp/react_webapp/urls.py
+++ b/react-webapp/react_webapp/urls.py
@@ -15,12 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
 
     # index 'home page' of the app
-    url(r'^$', views.index, name='index')
+    re_path(r'^$', views.index, name='index')
 ]


### PR DESCRIPTION
Update ``url`` import to ``re_path`` to support Django 4

This repository is mentioned in the documentation e.g. https://omero.readthedocs.io/en/stable/developers/Web/CreateApp.html